### PR TITLE
standardize build paths in libraries to prevent compilation overrides

### DIFF
--- a/packages/cloning-decorator/tsconfig.lib.json
+++ b/packages/cloning-decorator/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
     "declaration": true,
     "types": ["node"]
   },

--- a/packages/cloning-decorator/tsconfig.spec.json
+++ b/packages/cloning-decorator/tsconfig.spec.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/packages/contact-service/tsconfig.lib.json
+++ b/packages/contact-service/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
     "declaration": true,
     "module": "commonjs",
     "types": ["node"]

--- a/packages/contact-service/tsconfig.spec.json
+++ b/packages/contact-service/tsconfig.spec.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/packages/event-bus/tsconfig.lib.json
+++ b/packages/event-bus/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
     "declaration": true,
     "types": ["node"]
   },

--- a/packages/event-bus/tsconfig.spec.json
+++ b/packages/event-bus/tsconfig.spec.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/packages/status-service/tsconfig.lib.json
+++ b/packages/status-service/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
     "declaration": true,
     "module": "commonjs",
     "types": ["node"]

--- a/packages/status-service/tsconfig.spec.json
+++ b/packages/status-service/tsconfig.spec.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/packages/storage/tsconfig.lib.json
+++ b/packages/storage/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
     "declaration": true,
     "types": ["node"]
   },

--- a/packages/storage/tsconfig.spec.json
+++ b/packages/storage/tsconfig.spec.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
     "module": "commonjs",
     "types": ["jest", "node"]
   },


### PR DESCRIPTION
closes https://github.com/orgs/adorsys/projects/6/views/3?sliceBy%5Bvalue%5D=Awambeng&pane=issue&itemId=83300028&issue=adorsys%7Ceudiw-app%7C253